### PR TITLE
Bump version of Julia to 10.4

### DIFF
--- a/roles/julia/tasks/main_lin.yml
+++ b/roles/julia/tasks/main_lin.yml
@@ -4,9 +4,9 @@
     file:
       path: /opt/Julia
       state: directory
-  - name: Download and unpack Eclipse
+  - name: Download and unpack Julia
     unarchive:
-      src: https://julialang-s3.julialang.org/bin/linux/x64/1.9/julia-1.9.3-linux-x86_64.tar.gz
+      src: https://julialang-s3.julialang.org/bin/linux/x64/1.10/julia-1.10.4-linux-x86_64.tar.gz
       dest: /opt/Julia
       remote_src: yes
 

--- a/roles/julia/tasks/main_win.yml
+++ b/roles/julia/tasks/main_win.yml
@@ -1,4 +1,4 @@
 - name: Install Julia
   win_package:
-    path: https://julialang-s3.julialang.org/bin/winnt/x64/1.9/julia-1.9.3-win64.exe
+    path: https://julialang-s3.julialang.org/bin/winnt/x64/1.10/julia-1.10.4-win64.exe
     arguments: /VerySilent /AllUsers

--- a/roles/linroom/tasks/julia.yml
+++ b/roles/linroom/tasks/julia.yml
@@ -4,9 +4,9 @@
     file:
       path: /opt/Julia
       state: directory
-  - name: Download and unpack Eclipse
+  - name: Download and unpack Julia
     unarchive:
-      src: https://julialang-s3.julialang.org/bin/linux/x64/1.9/julia-1.9.3-linux-x86_64.tar.gz
+      src: https://julialang-s3.julialang.org/bin/linux/x64/1.10/julia-1.10.4-linux-x86_64.tar.gz
       dest: /opt/Julia
       remote_src: yes
 

--- a/roles/winroom/tasks/julia.yml
+++ b/roles/winroom/tasks/julia.yml
@@ -1,4 +1,4 @@
 - name: Install Julia
   win_package:
-    path: https://julialang-s3.julialang.org/bin/winnt/x64/1.9/julia-1.9.3-win64.exe
+    path: https://julialang-s3.julialang.org/bin/winnt/x64/1.10/julia-1.10.4-win64.exe
     arguments: /VerySilent /AllUsers


### PR DESCRIPTION
A simple bump of the current stable version of Julia language. 

BTW. The download url is duplicated into 2 files for each OS (linux and windows). It might make sense to remove the one that is not used.